### PR TITLE
Update GeneralBlockPanelKernel.h

### DIFF
--- a/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+++ b/Eigen/src/Core/products/GeneralBlockPanelKernel.h
@@ -719,11 +719,11 @@ class gebp_traits<std::complex<RealScalar>, std::complex<RealScalar>, ConjLhs_, 
     LhsPacketSize = Vectorizable ? unpacket_traits<LhsPacket_>::size : 1,
     RhsPacketSize = Vectorizable ? unpacket_traits<RhsScalar>::size : 1,
     RealPacketSize = Vectorizable ? unpacket_traits<RealPacket>::size : 1,
-    //NumberOfRegisters = EIGEN_ARCH_DEFAULT_NUMBER_OF_REGISTERS,
+    NumberOfRegisters = EIGEN_ARCH_DEFAULT_NUMBER_OF_REGISTERS,
 
     nr = 4,
-    mr = ResPacketSize,
-    mr = ResPacketSize, //(plain_enum_min(16, NumberOfRegisters) / 2 / nr) * ,
+    //mr = ResPacketSize,
+    mr = (plain_enum_min(16, NumberOfRegisters) / 2 / nr) * ResPacketSize,ResPacketSize, //(plain_enum_min(16, NumberOfRegisters) / 2 / nr) * ,
 
     LhsProgress = ResPacketSize,
     RhsProgress = 1
@@ -797,8 +797,8 @@ class gebp_traits<std::complex<RealScalar>, std::complex<RealScalar>, ConjLhs_, 
                                                                                          DoublePacket<ResPacketType>& c,
                                                                                          TmpType& /*tmp*/,
                                                                                          const LaneIdType&) const {
-                                                                                          c.first = padd(pmul(a, b.first), c.first);
-                                                                                          c.second = padd(pmul(a, b.second), c.second);
+    c.first = pmadd(a, b.first, c.first);
+    c.second = pmadd(a, b.second, c.second);
   }
 
   template <typename LaneIdType>


### PR DESCRIPTION
This update aims to enhance performance by optimizingregister usage and leveraging effi cient arithmeticoperations for complex numbers multiplication

This fixes an old TODO to make the block panel size in the m direction depend on the number of registers for complex * complex. It speeds up complex * complex matrix multiplication by 8-33%, depending on the type and backend (measured for std::complex<{float|double}> with SSE and AVX2).